### PR TITLE
Fix dependening on tide default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["*.png"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tide = "0.16"
+tide = { version = "0.16", default-features = false }
 tracing = "0.1"
 tracing-futures = "0.2"
 async-trait = "0.1"


### PR DESCRIPTION
Depending on tide-tracing requires a project to include all default features of tide even though tide-tracing doesn't need any of them. This fix minimizes the required tide features so dependents don't get any extra unneeded features 😄