### PR TITLE
chore: bump edition to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ A simple middleware for [`tide`](https://github.com/http-rs/tide) using the [`tr
 """
 documentation = "https://docs.rs/tide-tracing/"
 repository = "https://github.com/ethanboxx/tide-tracing"
-edition = "2018"
+edition = "2021"
 rust-version = "1.63"
 exclude = ["*.png"]
 


### PR DESCRIPTION
Our msrv of `1.63` supports edition:2021 so we might as well use it
