### PR TITLE
docs: remove markdown from description

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Ethan Brierley <ethanboxx@gmail.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 description = """
-A simple middleware for [`tide`](https://github.com/http-rs/tide) using the [`tracing`](https://github.com/tokio-rs/tracing) crate for logging.
+A simple middleware for tide using the tracing crate for logging.
 """
 keywords = ["tide", "tracing", "logging", "middleware", "opentelemetry"]
 documentation = "https://docs.rs/tide-tracing/"


### PR DESCRIPTION
crates.io does not render markdown in the description
